### PR TITLE
feat: Parallelize calls to multiple next pages

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,14 +24,14 @@
     },
     {
       "type": "swift",
-      "args": ["build", "--sanitize=thread", "--product", "githubstats"],
+      "args": ["build", "--sanitize=thread", "--build-tests"],
       "cwd": "",
       "problemMatcher": ["$swiftc"],
       "group": {
         "kind": "build",
       },
       "label": "swift: Build with thread sanitizer",
-      "detail": "swift build --sanitize=thread --product githubstats",
+      "detail": "swift build --sanitize=thread --build-tests",
       "dependsOn": ["swift: Resolve package dependencies"]
     },
     {
@@ -57,7 +57,7 @@
       },
       "label": "swift: Test with thread sanitizer",
       "detail": "swift test --sanitize=thread",
-      "dependsOn": ["swift build --sanitize=thread --product githubstats"]
+      "dependsOn": ["swift build --sanitize=thread --build-tests"]
     },
     {
       "type": "swift",

--- a/Sources/GitHubStatsCore/Endpoints/EndpointConstants.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointConstants.swift
@@ -16,8 +16,10 @@ internal enum GitHubConstants {
 
     static let defaultMaxResults = 100
     
+    static let numberOfConcurrentFetches = 3
+
     static let nextPageLinkHeader = "link"
 
-    // <https://api.github.com/repositories/44838949/pulls?state=closed&page=2>; rel="next", <https://api.github.com/repositories/44838949/pulls?state=closed&page=1599>; rel="last"
     static let nextPageLinkRegex = #/<([^>]+)>; rel="next"/# //i;
+    static let nextPageLinkAndLastPageRegex = #/<([^>]+)&page=(\d+)>; rel="next", <[^>]+&page=(\d+)>; rel="last"/# //i;
 }

--- a/Sources/GitHubStatsCore/Endpoints/EndpointEnvironment.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointEnvironment.swift
@@ -1,0 +1,15 @@
+//
+//  EndpointEnvironment.swift
+//
+//
+//  Created by Jesse Wesson on 10/18/23.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+internal enum EndpointEnvironment {
+    static var urlSessionConfiguration = URLSessionConfiguration.default
+}

--- a/Sources/GitHubStatsCore/Endpoints/EndpointError.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointError.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public enum EndpointError: Error {
     case urlSessionError
+    case rateLimitError(retryAfterSeconds: Int)
     case unsuccessfulResponseError(httpResponseStatusCode: Int)
     case unknownError
 }

--- a/Sources/GitHubStatsCore/Endpoints/EndpointSession.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointSession.swift
@@ -13,51 +13,98 @@ import FoundationNetworking
 public struct EndpointSession {
     private let endpointRequest: EndpointRequest
 
+    private var session: URLSession
+
     internal init(endpointRequest: EndpointRequest) {
         self.endpointRequest = endpointRequest
-    }
 
+        let configuration = EndpointEnvironment.urlSessionConfiguration
+        // configuration.httpMaximumConnectionsPerHost = 3
+        session = URLSession.init(configuration: configuration)
+        session.sessionDescription = "GitHub Endpoint Session"
+    }
+    
     // TODO: replace RequestFilter<PullRequestFilter> with generic type
     public func callEndpoint<T: GitHubObject>(filter: RequestFilter<T>) async throws -> [T] {
         var results = Array<T>()
-
-        var url = endpointRequest.makeRequest(queryParameters: filter.queryParameters)
+        
+        let url = endpointRequest.makeRequest(queryParameters: filter.queryParameters)
+        var urlsToFetch = [URLRequest]()
+        var urlsToFetchNext = [url]
+        
         var shouldContinue = false
-
+        
         repeat {
-            // rethrow error from callEndpoint
-            let result = try await callEndpoint(url: url)
+            let urlsToFetchCount = urlsToFetchNext.count > GitHubConstants.numberOfConcurrentFetches
+                                    ? GitHubConstants.numberOfConcurrentFetches
+                                    : urlsToFetchNext.count
+            let urlsToFetchRange = 0..<urlsToFetchCount
+            urlsToFetch = Array(urlsToFetchNext[urlsToFetchRange])
+            urlsToFetchNext.removeSubrange(urlsToFetchRange)
+            var httpResults = [(data: Data, httpResponse: HTTPURLResponse)]()
             
-            let resultsPage: [T] = try JSONDecoder().decode([T].self, from: result.data)
-            if let filterFunction = filter.filterFunction {
-                let filteredResults = resultsPage.filter(filterFunction)
-                results.append(contentsOf: filteredResults)
-            } else {
-                results.append(contentsOf: resultsPage)
+            let _ = try await withThrowingTaskGroup(of: (data: Data, httpResponse: HTTPURLResponse).self) { taskGroup in
+                for url in urlsToFetch {
+                    taskGroup.addTask {
+                        var retry = false
+                        repeat {
+                            do{
+                                return try await callEndpoint(url: url)
+                            } catch EndpointError.rateLimitError(let retryAfterSeconds) {
+                                retry = true
+                                try await Task.sleep(nanoseconds: UInt64(retryAfterSeconds * 1_000_000_000))
+                            } catch let error {
+                                throw error
+                            }
+                        } while retry
+                    }
+                }
+                
+                while let result = try await taskGroup.next() {
+                    httpResults.append(result)
+                }
+                
+                return httpResults
+            }
+            
+            guard httpResults.count > 0 else {
+                throw EndpointError.unknownError
+            }
+
+            for result in httpResults {
+                let resultsPage: [T] = try JSONDecoder().decode([T].self, from: result.data)
+                if let filterFunction = filter.filterFunction {
+                    let filteredResults = resultsPage.filter(filterFunction)
+                    results.append(contentsOf: filteredResults)
+                } else {
+                    results.append(contentsOf: resultsPage)
+                }
             }
 
             let maxResults = filter.maxResults
             if results.count >= maxResults {
                 results.removeSubrange(maxResults...)
                 shouldContinue = false
-            } else if let nextPageUrl = getNextPageUrl(from: result.httpResponse) {
-                url = endpointRequest.makeNextRequest(with: nextPageUrl)
+            } else if urlsToFetchNext.count > 0 {
+                shouldContinue = true
+            } else if httpResults.count == 1, let nextPageUrls = getNextPagesUrls(from: httpResults.first!.httpResponse) {
+                urlsToFetchNext = nextPageUrls.map { endpointRequest.makeNextRequest(with: $0) }
                 shouldContinue = true
             } else {
                 shouldContinue = false
             }
         } while shouldContinue
-
+        
         return results
     }
-
+    
     private func callEndpoint(url: URLRequest) async throws -> (data: Data, httpResponse: HTTPURLResponse) {
         var result: (data: Data, response: URLResponse)? = nil
-
+        
         do {
 #if os(Linux)
             result = try await withCheckedThrowingContinuation { continuation in
-                URLSession.shared.dataTask(with: url) { data, response, error in
+                session.dataTask(with: url) { data, response, error in
                     if let data, let response {
                         continuation.resume(returning: (data, response))
                     } else if let error = error {
@@ -68,12 +115,12 @@ public struct EndpointSession {
                 }.resume()
             }
 #else
-            result = try await URLSession.shared.data(for: url)
+            result = try await session.data(for: url)
 #endif
         } catch {
             print(error)
         }
-
+        
         guard let result else {
             throw EndpointError.urlSessionError
         }
@@ -81,22 +128,79 @@ public struct EndpointSession {
         guard let httpResponse = result.response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             let httpResponse = result.response as? HTTPURLResponse
             let statusCode = httpResponse?.statusCode ?? 418
-            throw EndpointError.unsuccessfulResponseError(httpResponseStatusCode: statusCode)
+            
+            if statusCode == 403, let retryAfter = httpResponse?.value(forHTTPHeaderField: "Retry-After") {
+                throw EndpointError.rateLimitError(retryAfterSeconds: Int(retryAfter) ?? 60)
+            } else {
+                throw EndpointError.unsuccessfulResponseError(httpResponseStatusCode: statusCode)
+            }
         }
-
+        
         return (result.data, httpResponse)
     }
-
+    
+    @available(*, deprecated, message: "Use EndpointSession.getNextPagesUrls(from:) instead")
     func getNextPageUrl(from response: HTTPURLResponse) -> URL? {
         guard let linkHeader = response.value(forHTTPHeaderField: GitHubConstants.nextPageLinkHeader) else {
             return nil
         }
-
+        
+        return EndpointSession.getNextPageUrl(from: linkHeader)
+    }
+    
+    @available(*, deprecated, message: "Use EndpointSession.getNextPagesUrls(from:) instead")
+    static func getNextPageUrl(from linkHeader: String) -> URL? {
         guard let match = linkHeader.firstMatch(of: GitHubConstants.nextPageLinkRegex) else {
             return nil
         }
-
+        
         let (_, nextPage) = match.output
         return URL(string: String(nextPage))
+    }
+    
+    func getNextPagesUrls(from response: HTTPURLResponse) -> [URL]? {
+        guard let linkHeader = response.value(forHTTPHeaderField: GitHubConstants.nextPageLinkHeader) else {
+            return nil
+        }
+        
+        return EndpointSession.getNextPagesUrls(from: linkHeader)
+    }
+    
+    static func getNextPagesUrls(from linkHeader: String) -> [URL]? {
+        guard let match = linkHeader.firstMatch(of: GitHubConstants.nextPageLinkAndLastPageRegex) else {
+            return nil
+        }
+        
+        let (_, nextPageBaseURL, nextPageNumber, lastPageNumber) = match.output
+        
+        let start = Int(String(nextPageNumber)) ?? 0
+        let end = Int(String(lastPageNumber)) ?? 0
+        
+        let nextPageURL = URL(string: String(nextPageBaseURL))
+        guard let nextPageURL else {
+            return nil
+        }
+        
+        var nextPageURLs = Array<URL>()
+        for pageNumber in start...end {
+            // convert int to string
+            let page = String(pageNumber)
+#if os(Linux)
+            var urlBuilder = URLComponents(url: nextPageURL, resolvingAgainstBaseURL: false)
+            
+            if let queryItems = urlBuilder?.queryItems, queryItems.isEmpty {
+                urlBuilder?.queryItems = [URLQueryItem(name: "page", value: page)]
+            } else {
+                urlBuilder?.queryItems?.append(contentsOf: [URLQueryItem(name: "page", value: page)])
+            }
+            
+            let pageURL = urlBuilder!.url!
+#else
+            let pageURL = nextPageURL.appending(queryItems: [URLQueryItem(name: "page", value: page)])
+#endif
+            nextPageURLs.append(pageURL)
+        }
+        
+        return nextPageURLs
     }
 }

--- a/Tests/GitHubStatsCoreTests/EndpointSessionTests.swift
+++ b/Tests/GitHubStatsCoreTests/EndpointSessionTests.swift
@@ -1,0 +1,55 @@
+//
+//  EndpointSessionTests.swift
+//  GitHubStats
+//
+//  Created by Jesse Wesson on 2023-08-30.
+//
+
+import XCTest
+@testable import GitHubStatsCore
+
+final class EndpointSessionTests: XCTestCase {
+    private let linkHeader = """
+        <https://api.github.com/repositories/44838949/pulls?state=closed&page=2>; rel="next", \
+        <https://api.github.com/repositories/44838949/pulls?state=closed&page=10>; rel="last"
+        """
+
+    func testGetNextPagesUrl() async throws {
+        // Arrange
+        let nextPageUrl = URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=2")
+        
+        // Act
+        let urls = EndpointSession.getNextPageUrl(from:linkHeader)
+
+        // Assert
+        XCTAssertNotNil(urls)
+        XCTAssertEqual(urls, nextPageUrl)
+        
+    }
+    
+    func testGetNextPagesUrls() async throws {
+        // Arrange
+        let nextPageUrls = [
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=2"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=3"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=4"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=5"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=6"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=7"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=8"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=9"),
+                URL(string: "https://api.github.com/repositories/44838949/pulls?state=closed&page=10")
+                ]
+        
+        // Act
+        let urls = EndpointSession.getNextPagesUrls(from:linkHeader)
+
+        // Assert
+        XCTAssertNotNil(urls)
+        if let urls {
+            XCTAssertEqual(urls.count, 9)
+            XCTAssertEqual(urls, nextPageUrls)
+        }
+    }
+}
+


### PR DESCRIPTION
feat: Parallelize calls to multiple next pages

Handle multiple multiple pages in link header
- Create new function to extract and return all the next page URLs using a new regex in EndpointConstants
- Refactor and add tests for the getNextPagesUrl() and getNextPagesUrls() functions

Enable parallel calls to follow on pages
- Get multiple next pages and process these responses via TaskGroups limited by number of current fetches in EndpointConstants
- Build in preliminary support for GitHub rate limiting their API calls by detecting 403 response codes and checking for a `Retry-After` header
- Throw EndpointError.rateLimitExceeded error with `Retry-After` seconds associated value to use as back off delay before retrying the call
- Use a new URLSessionConfiguration in EndpointEnvironment to create the URLSession in EndpointSession so that the performance tests can use the `ephemeral` URLSessionConfiguration that doesn't use any caching
- Update Linux specific code to support this new functionality

Other changes
- Change thread sanitizer builds and tests to build --build-tests