### PR TITLE
refactor: callEndpoint to reduce function length

### DIFF
--- a/Sources/GitHubStatsCore/Endpoints/EndpointConstants.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointConstants.swift
@@ -12,6 +12,11 @@ internal enum GitHubConstants {
 
     static let gitHubTokenEnvironmentVariable = "TEST_GITHUB_TOKEN"
 
+    static let gitHubUserAgentString = "github-stats-cli"
+
+    static let retryAfterHeader = "Retry-After"
+    static let contentTypeHeader = "Content-Type"
+
     static let gitHubUrlRegex = #/^git@github\.com:(?<org>[\w\-\.]+)/(?<repo>[\w\-\.]+)$/#
 
     static let defaultMaxResults = 100

--- a/Sources/GitHubStatsCore/Endpoints/EndpointError.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointError.swift
@@ -10,6 +10,6 @@ import Foundation
 public enum EndpointError: Error {
     case urlSessionError
     case rateLimitError(retryAfterSeconds: Int)
-    case unsuccessfulResponseError(httpResponseStatusCode: Int)
+    case unsuccessfulResponseError(httpResponseStatusCode: Int, httpResponseBody: String?)
     case unknownError
 }

--- a/Sources/GitHubStatsCore/Endpoints/EndpointRequest.swift
+++ b/Sources/GitHubStatsCore/Endpoints/EndpointRequest.swift
@@ -56,6 +56,7 @@ public struct EndpointRequest {
         request.httpMethod = "GET"
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        request.setValue(GitHubConstants.gitHubUserAgentString, forHTTPHeaderField: "User-Agent")
 
         if let token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/Sources/GitHubStatsCore/Models/GitHubError.swift
+++ b/Sources/GitHubStatsCore/Models/GitHubError.swift
@@ -1,0 +1,14 @@
+//
+//  GitHubError.swift
+//  
+//
+//  Created by Jesse Wesson on 6/29/24.
+//
+
+import Foundation
+
+public struct GitHubError: GitHubObject {
+    public var message: String
+    public var documentation_url: URL
+    public var status: String
+}

--- a/Tests/GitHubStatsCoreTests/EndpointTests.swift
+++ b/Tests/GitHubStatsCoreTests/EndpointTests.swift
@@ -28,6 +28,7 @@ final class EndpointTests: XCTestCase {
         var pullRequests: [PullRequest]?
         var thrownError: Error?
         var returnedStatusCode: Int?
+        var returnedBody: String?
         do {
             let filter = PullRequestFilterFactory.makeDefaultRequestFilter()
             pullRequests = try await repo.getPullRequests(filter: filter)
@@ -36,10 +37,12 @@ final class EndpointTests: XCTestCase {
             thrownError = error
 
             switch error {
-                case .unsuccessfulResponseError(let responseCode):
-                    returnedStatusCode = responseCode
-                default:
-                    XCTFail("Control flow should never reach here")
+            case .unsuccessfulResponseError(let responseCode, let httpResponseBody):
+                returnedStatusCode = responseCode
+                returnedBody = httpResponseBody
+
+            default:
+                XCTFail("Control flow should never reach here")
             }
         } catch {
             XCTFail("Control flow should never reach here")
@@ -51,6 +54,7 @@ final class EndpointTests: XCTestCase {
         XCTAssertTrue(thrownError is EndpointError)
         XCTAssertNotNil(returnedStatusCode)
         XCTAssertEqual(returnedStatusCode!, 404)
+        XCTAssertNotNil(returnedBody)
     }
 
     func testGetPullRequests() async throws {
@@ -160,7 +164,7 @@ final class EndpointTests: XCTestCase {
                 expectation.fulfill()
             }
 
-            self.wait(for: [expectation], timeout: 240)
+            self.wait(for: [expectation], timeout: 120)
         }
 
 #if os(Linux)


### PR DESCRIPTION
Refactor callEndpoint to use callEndpointWithRetry to address future
    function_body_length lint issue
Add User-Agent string when calling GitHub APIs and
Also, refactor error handling and capture HTTP response body when
    encountering an error